### PR TITLE
Python bugs

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -53820,7 +53820,7 @@ function rewritePath(options, filename) {
                 return newPath;
             });
         }
-        let filepath;
+        let filepath = filename;
         if (options.source_base_path_1 || options.source_base_path_2 || options.source_base_path_3) {
             const orgPath1 = options.source_base_path_1.split(":");
             const orgPath2 = options.source_base_path_2.split(":");

--- a/dist/index.js
+++ b/dist/index.js
@@ -53820,7 +53820,7 @@ function rewritePath(options, filename) {
                 return newPath;
             });
         }
-        let filepath = filename;
+        let filepath;
         if (options.source_base_path_1 || options.source_base_path_2 || options.source_base_path_3) {
             const orgPath1 = options.source_base_path_1.split(":");
             const orgPath2 = options.source_base_path_2.split(":");
@@ -53862,6 +53862,9 @@ function rewritePath(options, filename) {
                 }
             }
             console.log('Rewritten Filepath: ' + filepath);
+        }
+        else { // if no source_base_path is provided, return the original path
+            filepath = filename;
         }
         return filepath;
     });

--- a/src/rewritePath.ts
+++ b/src/rewritePath.ts
@@ -16,7 +16,7 @@ export async function rewritePath(options:any, filename:any){
         return newPath
     }
 
-    let filepath
+    let filepath = filename
 
     if (options.source_base_path_1 || options.source_base_path_2 || options.source_base_path_3){
         const orgPath1 = options.source_base_path_1.split(":")

--- a/src/rewritePath.ts
+++ b/src/rewritePath.ts
@@ -16,7 +16,7 @@ export async function rewritePath(options:any, filename:any){
         return newPath
     }
 
-    let filepath = filename
+    let filepath
 
     if (options.source_base_path_1 || options.source_base_path_2 || options.source_base_path_3){
         const orgPath1 = options.source_base_path_1.split(":")
@@ -65,6 +65,8 @@ export async function rewritePath(options:any, filename:any){
             }
         }
         console.log('Rewritten Filepath: '+filepath);
+    } else { // if no source_base_path is provided, return the original path
+        filepath = filename
     }
     return filepath
 }


### PR DESCRIPTION
For `files: changed` option , when the src_base_path is empty , action is crashing. This code change fixes it by adding the filepath correctly inside the relevant function.